### PR TITLE
Update to Java 17 and CDI

### DIFF
--- a/excepciones/pom.xml
+++ b/excepciones/pom.xml
@@ -17,7 +17,7 @@
         </dependency>
     </dependencies>
     <properties>
-        <maven.compiler.source>1.7</maven.compiler.source>
-        <maven.compiler.target>1.7</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
     </properties>
 </project>

--- a/logica/pom.xml
+++ b/logica/pom.xml
@@ -10,12 +10,11 @@
     <groupId>com.infoloxa.catequesis</groupId>
     <artifactId>logica</artifactId>
     <version>1.0</version>
-    <packaging>ejb</packaging>
+    <packaging>jar</packaging>
 
     <name>logica</name>
 
     <properties>
-        <endorsed.dir>${project.build.directory}/endorsed</endorsed.dir>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
@@ -45,47 +44,11 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.1</version>
+                <version>3.11.0</version>
                 <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
-                    <compilerArguments>
-                        <endorseddirs>${endorsed.dir}</endorseddirs>
-                    </compilerArguments>
+                    <source>17</source>
+                    <target>17</target>
                 </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-ejb-plugin</artifactId>
-                <version>2.3</version>
-                <configuration>
-                    <ejbVersion>3.1</ejbVersion>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-dependency-plugin</artifactId>
-                <version>2.6</version>
-                <executions>
-                    <execution>
-                        <phase>validate</phase>
-                        <goals>
-                            <goal>copy</goal>
-                        </goals>
-                        <configuration>
-                            <outputDirectory>${endorsed.dir}</outputDirectory>
-                            <silent>true</silent>
-                            <artifactItems>
-                                <artifactItem>
-                                    <groupId>javax</groupId>
-                                    <artifactId>javaee-endorsed-api</artifactId>
-                                    <version>7.0</version>
-                                    <type>jar</type>
-                                </artifactItem>
-                            </artifactItems>
-                        </configuration>
-                    </execution>
-                </executions>
             </plugin>
         </plugins>
     </build>

--- a/logica/src/main/java/com/infoloxa/catequesis/logica/NewSessionBean.java
+++ b/logica/src/main/java/com/infoloxa/catequesis/logica/NewSessionBean.java
@@ -4,15 +4,13 @@
  */
 package com.infoloxa.catequesis.logica;
 
-import javax.ejb.Stateless;
-import javax.ejb.LocalBean;
+import javax.enterprise.context.ApplicationScoped;
 
 /**
  *
  * @author martin
  */
-@Stateless
-@LocalBean
+@ApplicationScoped
 public class NewSessionBean {
 
     public void businessMethod() {

--- a/logica/src/main/java/com/infoloxa/catequesis/logica/dao/EstudianteDao.java
+++ b/logica/src/main/java/com/infoloxa/catequesis/logica/dao/EstudianteDao.java
@@ -7,13 +7,11 @@ package com.infoloxa.catequesis.logica.dao;
 
 import com.infoloxa.catequesis.model.Estudiantes;
 import java.util.List;
-import javax.ejb.Local;
 
 /**
  *
  * @author anthoserv
  */
-@Local
 public interface EstudianteDao extends IGenericDao<Estudiantes, Long>  {
 /**
  * sssssssjjdjfjajdja

--- a/logica/src/main/java/com/infoloxa/catequesis/logica/dao/IGenericDao.java
+++ b/logica/src/main/java/com/infoloxa/catequesis/logica/dao/IGenericDao.java
@@ -14,7 +14,6 @@ import com.infoloxa.catequesis.excepciones.EntidadNoGrabadaException;
 import java.io.Serializable;
 import java.util.List;
 import java.util.Map;
-import javax.ejb.Local;
 
 /**
  * Interface IGenericDao.
@@ -24,7 +23,6 @@ import javax.ejb.Local;
  * @author Eduardo Proano
  * @revision $Revision: 1.1 $$
  */
-@Local
 public interface IGenericDao<T, PK extends Serializable> {
 
     /**

--- a/logica/src/main/java/com/infoloxa/catequesis/logica/dao/Imp/EstudianteDaoImpl.java
+++ b/logica/src/main/java/com/infoloxa/catequesis/logica/dao/Imp/EstudianteDaoImpl.java
@@ -5,10 +5,10 @@ import com.infoloxa.catequesis.logica.dao.EstudianteDao;
 import com.infoloxa.catequesis.logica.dao.GenericDao;
 import com.infoloxa.catequesis.model.Estudiantes;
 import java.util.List;
-import javax.ejb.Stateless;
+import javax.enterprise.context.ApplicationScoped;
 import javax.persistence.Query;
 
-@Stateless
+@ApplicationScoped
 public class EstudianteDaoImpl extends GenericDao<Estudiantes, Long> implements EstudianteDao {
 
     public EstudianteDaoImpl() {

--- a/logica/src/main/java/com/infoloxa/catequesis/logica/dao/Imp/SacramentoDaoImpl.java
+++ b/logica/src/main/java/com/infoloxa/catequesis/logica/dao/Imp/SacramentoDaoImpl.java
@@ -4,9 +4,9 @@ package com.infoloxa.catequesis.logica.dao.Imp;
 import com.infoloxa.catequesis.logica.dao.GenericDao;
 import com.infoloxa.catequesis.logica.dao.SacramentoDao;
 import com.infoloxa.catequesis.model.Sacramentos;
-import javax.ejb.Stateless;
+import javax.enterprise.context.ApplicationScoped;
 
-@Stateless
+@ApplicationScoped
 public class SacramentoDaoImpl extends GenericDao<Sacramentos, Long> implements SacramentoDao {
 
     public SacramentoDaoImpl() {

--- a/logica/src/main/java/com/infoloxa/catequesis/logica/dao/SacramentoDao.java
+++ b/logica/src/main/java/com/infoloxa/catequesis/logica/dao/SacramentoDao.java
@@ -6,13 +6,11 @@
 package com.infoloxa.catequesis.logica.dao;
 
 import com.infoloxa.catequesis.model.Sacramentos;
-import javax.ejb.Local;
 
 /**
  *
  * @author anthoserv
  */
-@Local
 public interface SacramentoDao extends IGenericDao<Sacramentos, Long>  {
     
 }

--- a/logica/src/main/java/com/infoloxa/catequesis/logica/servicios/CatequesisService.java
+++ b/logica/src/main/java/com/infoloxa/catequesis/logica/servicios/CatequesisService.java
@@ -11,7 +11,6 @@ import com.infoloxa.catequesis.excepciones.EntidadNoGrabadaException;
 import com.infoloxa.catequesis.model.Estudiantes;
 import com.infoloxa.catequesis.model.Sacramentos;
 import java.util.List;
-import javax.ejb.Local;
 
 /**
  * <p>
@@ -21,7 +20,6 @@ import javax.ejb.Local;
  * @author anthoserv
  * @revision $Revision: $
  */
-@Local
 public interface CatequesisService {
 /**
  * 

--- a/logica/src/main/java/com/infoloxa/catequesis/logica/servicios/Imp/CatequesisServiceImpl.java
+++ b/logica/src/main/java/com/infoloxa/catequesis/logica/servicios/Imp/CatequesisServiceImpl.java
@@ -13,20 +13,20 @@ import com.infoloxa.catequesis.logica.servicios.CatequesisService;
 import com.infoloxa.catequesis.model.Estudiantes;
 import com.infoloxa.catequesis.model.Sacramentos;
 import java.util.List;
-import javax.ejb.EJB;
-import javax.ejb.Stateless;
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
 
 /**
  * Clase que permite realizar todo el proceso de facturación electtrónica
  *
  * @author anthoserv
  */
-@Stateless
+@ApplicationScoped
 public class CatequesisServiceImpl implements CatequesisService {
 
-    @EJB    
+    @Inject
     private EstudianteDao estudiantesDao;
-    @EJB    
+    @Inject
     private SacramentoDao sacramentoDao;
     
     @Override

--- a/model/pom.xml
+++ b/model/pom.xml
@@ -25,7 +25,7 @@
         </dependency>
     </dependencies>
     <properties>
-        <maven.compiler.source>1.7</maven.compiler.source>
-        <maven.compiler.target>1.7</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
     </properties>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -10,9 +10,11 @@
         <module>logica</module>
         <module>vistas</module>
         <module>excepciones</module>
-        
+
     </modules>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
     </properties>
 </project>

--- a/vistas/pom.xml
+++ b/vistas/pom.xml
@@ -15,7 +15,6 @@
     <name>vistas</name>
 
     <properties>
-        <endorsed.dir>${project.build.directory}/endorsed</endorsed.dir>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
     
@@ -44,10 +43,10 @@
             <version>7.0</version>
             <scope>provided</scope>
         </dependency>
-          <dependency>
+        <dependency>
             <groupId>org.primefaces</groupId>
             <artifactId>primefaces</artifactId>
-            <version>5.2</version>
+            <version>14.0.0</version>
             <type>jar</type>
         </dependency>
         <dependency>
@@ -75,13 +74,10 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.1</version>
+                <version>3.11.0</version>
                 <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
-                    <compilerArguments>
-                        <endorseddirs>${endorsed.dir}</endorseddirs>
-                    </compilerArguments>
+                    <source>17</source>
+                    <target>17</target>
                 </configuration>
             </plugin>
             <plugin>
@@ -91,31 +87,6 @@
                 <configuration>
                     <failOnMissingWebXml>false</failOnMissingWebXml>
                 </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-dependency-plugin</artifactId>
-                <version>2.6</version>
-                <executions>
-                    <execution>
-                        <phase>validate</phase>
-                        <goals>
-                            <goal>copy</goal>
-                        </goals>
-                        <configuration>
-                            <outputDirectory>${endorsed.dir}</outputDirectory>
-                            <silent>true</silent>
-                            <artifactItems>
-                                <artifactItem>
-                                    <groupId>javax</groupId>
-                                    <artifactId>javaee-endorsed-api</artifactId>
-                                    <version>7.0</version>
-                                    <type>jar</type>
-                                </artifactItem>
-                            </artifactItems>
-                        </configuration>
-                    </execution>
-                </executions>
             </plugin>
         </plugins>
     </build>

--- a/vistas/src/main/java/com/infoloxa/catequesis/vistas/EstudianteController.java
+++ b/vistas/src/main/java/com/infoloxa/catequesis/vistas/EstudianteController.java
@@ -9,17 +9,15 @@ package com.infoloxa.catequesis.vistas;
 
 import com.infoloxa.catequesis.excepciones.EntidadNoGrabadaException;
 import com.infoloxa.catequesis.logica.servicios.CatequesisService;
-import com.infoloxa.catequesis.logica.servicios.Imp.CatequesisServiceImpl;
 import com.infoloxa.catequesis.model.Estudiantes;
 import java.io.Serializable;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import javax.ejb.EJB;
 import javax.faces.application.FacesMessage;
-import javax.faces.bean.ViewScoped;
-import javax.faces.bean.ManagedBean;
-import javax.faces.bean.ManagedProperty;
+import javax.faces.view.ViewScoped;
+import javax.inject.Inject;
+import javax.inject.Named;
 import javax.faces.context.FacesContext;
 
 /**
@@ -28,15 +26,15 @@ import javax.faces.context.FacesContext;
  * @author Miguel Paredes
  * @revision $Revision: $
  */
-@ManagedBean(name = "estudianteController")
+@Named("estudianteController")
 @ViewScoped
 public class EstudianteController implements Serializable {
     private static final long serialVersionUID = 2894565334915564100L;
 
-    @ManagedProperty(value = "#{estudianteDM}")
+    @Inject
     private EstudianteDM estudianteDM;
 
-    @EJB(lookup = "java:global/logica-1.0/CatequesisServiceImpl!com.infoloxa.catequesis.logica.servicios.CatequesisService")
+    @Inject
     CatequesisService catequesisServicio;
     
     public void inform(){

--- a/vistas/src/main/java/com/infoloxa/catequesis/vistas/EstudianteDM.java
+++ b/vistas/src/main/java/com/infoloxa/catequesis/vistas/EstudianteDM.java
@@ -9,16 +9,19 @@ package com.infoloxa.catequesis.vistas;
 import com.infoloxa.catequesis.model.Estudiantes;
 import java.util.ArrayList;
 import java.util.List;
-import javax.faces.bean.ManagedBean;
-import javax.faces.bean.ViewScoped;
+import javax.inject.Named;
+import javax.faces.view.ViewScoped;
+import java.io.Serializable;
 
 /**
  *
  * @author anthoserv
  */
-@ManagedBean(name = "estudianteDM")
+@Named("estudianteDM")
 @ViewScoped
-public class EstudianteDM {
+public class EstudianteDM implements Serializable {
+
+    private static final long serialVersionUID = 1L;
 
     private List<Estudiantes> listaEstudiantes= new ArrayList<>();
     private Estudiantes estudiantes= new Estudiantes();


### PR DESCRIPTION
## Summary
- set compiler level to Java 17 for all modules
- switch business layer from EJB to CDI
- convert JSF managed beans to CDI beans
- remove old endorsed dirs/plugins
- upgrade PrimeFaces dependency to version 14

## Testing
- `mvn -v` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_6844cf131950832a985b922e74ae9ed2