### PR TITLE
Add simple session-based login

### DIFF
--- a/logica/src/main/java/com/infoloxa/catequesis/logica/dao/GenericDao.java
+++ b/logica/src/main/java/com/infoloxa/catequesis/logica/dao/GenericDao.java
@@ -102,8 +102,9 @@ public class GenericDao<T, PK extends Serializable> implements IGenericDao<T, PK
      */
     @Override
     public void eliminar(final T o) throws EntidadNoBorradaException {
-        em.merge(o);
-        em.remove(o);
+        // merge devuelve la entidad administrada. Usamos esa instancia para
+        // evitar IllegalArgumentException al intentar eliminar un objeto detachado
+        em.remove(em.merge(o));
     }
 
     /**

--- a/logica/src/main/java/com/infoloxa/catequesis/logica/dao/Imp/UsuarioDaoImpl.java
+++ b/logica/src/main/java/com/infoloxa/catequesis/logica/dao/Imp/UsuarioDaoImpl.java
@@ -1,0 +1,26 @@
+package com.infoloxa.catequesis.logica.dao.Imp;
+
+import com.infoloxa.catequesis.logica.dao.GenericDao;
+import com.infoloxa.catequesis.logica.dao.UsuarioDao;
+import com.infoloxa.catequesis.model.Usuarios;
+import java.util.List;
+import javax.ejb.Stateless;
+import javax.persistence.Query;
+
+@Stateless
+public class UsuarioDaoImpl extends GenericDao<Usuarios, Long> implements UsuarioDao {
+
+    public UsuarioDaoImpl() {
+        super(Usuarios.class);
+    }
+
+    @Override
+    public List<Usuarios> buscarUsuario(String usuario, String clave) {
+        StringBuilder sql = new StringBuilder();
+        sql.append("select u from Usuarios u where u.usuario = ?1 and u.clave = ?2");
+        Query query = em.createQuery(sql.toString());
+        query.setParameter(1, usuario);
+        query.setParameter(2, clave);
+        return (List<Usuarios>) query.getResultList();
+    }
+}

--- a/logica/src/main/java/com/infoloxa/catequesis/logica/dao/UsuarioDao.java
+++ b/logica/src/main/java/com/infoloxa/catequesis/logica/dao/UsuarioDao.java
@@ -1,0 +1,10 @@
+package com.infoloxa.catequesis.logica.dao;
+
+import com.infoloxa.catequesis.model.Usuarios;
+import java.util.List;
+import javax.ejb.Local;
+
+@Local
+public interface UsuarioDao extends IGenericDao<Usuarios, Long> {
+    List<Usuarios> buscarUsuario(String usuario, String clave);
+}

--- a/logica/src/main/java/com/infoloxa/catequesis/logica/servicios/CatequesisService.java
+++ b/logica/src/main/java/com/infoloxa/catequesis/logica/servicios/CatequesisService.java
@@ -8,6 +8,7 @@ package com.infoloxa.catequesis.logica.servicios;
 
 
 import com.infoloxa.catequesis.excepciones.EntidadNoGrabadaException;
+import com.infoloxa.catequesis.excepciones.EntidadNoEncontradaException;
 import com.infoloxa.catequesis.model.Estudiantes;
 import com.infoloxa.catequesis.model.Sacramentos;
 import java.util.List;
@@ -34,8 +35,12 @@ public interface CatequesisService {
  * @param estudiantes
  * @throws EntidadNoGrabadaException 
  */
- void guardarEstudiantes(Estudiantes estudiantes) throws EntidadNoGrabadaException;
+void guardarEstudiantes(Estudiantes estudiantes) throws EntidadNoGrabadaException;
 
-    public List<Estudiantes> ontenerEstudiantes();
+List<Sacramentos> obtenerSacramentos();
+
+Estudiantes obtenerEstudiantePorCedula(String cedula) throws EntidadNoEncontradaException;
+
+List<Estudiantes> obtenerEstudiantes();
 
 }

--- a/logica/src/main/java/com/infoloxa/catequesis/logica/servicios/Imp/CatequesisServiceImpl.java
+++ b/logica/src/main/java/com/infoloxa/catequesis/logica/servicios/Imp/CatequesisServiceImpl.java
@@ -70,8 +70,9 @@ public class CatequesisServiceImpl implements CatequesisService {
      * 
      * @return 
      */
-    public List<Sacramentos> obtenerSacramentos(){
-      return sacramentoDao.findAll();
+    @Override
+    public List<Sacramentos> obtenerSacramentos() {
+        return sacramentoDao.findAll();
     }
     
     /**
@@ -80,18 +81,20 @@ public class CatequesisServiceImpl implements CatequesisService {
      * @return
      * @throws EntidadNoEncontradaException 
      */
-    public Estudiantes obtenerEstudiantePorCedula(String cedula) throws EntidadNoEncontradaException{
+    @Override
+    public Estudiantes obtenerEstudiantePorCedula(String cedula) throws EntidadNoEncontradaException {
         List<Estudiantes> obtenerEstudiantesCedula = estudiantesDao.obtenerEstudiantesCedula(cedula);
-    if(obtenerEstudiantesCedula.isEmpty()){
-        throw new EntidadNoEncontradaException("Estudiante no encontrado");
-    }
-    return obtenerEstudiantesCedula.get(0);
+        if (obtenerEstudiantesCedula.isEmpty()) {
+            throw new EntidadNoEncontradaException("Estudiante no encontrado");
+        }
+        return obtenerEstudiantesCedula.get(0);
     }
     /**
      * 
      * @return 
      */
-    public List<Estudiantes> ontenerEstudiantes(){
+    @Override
+    public List<Estudiantes> obtenerEstudiantes() {
         return estudiantesDao.findAll();
     }
 }

--- a/logica/src/main/resources/META-INF/persistence.xml
+++ b/logica/src/main/resources/META-INF/persistence.xml
@@ -5,6 +5,7 @@
     <jta-data-source>java:jboss/catequesisDS</jta-data-source>
     <class>com.infoloxa.catequesis.model.Estudiantes</class>
     <class>com.infoloxa.catequesis.model.Sacramentos</class>
+    <class>com.infoloxa.catequesis.model.Usuarios</class>
     <exclude-unlisted-classes>true</exclude-unlisted-classes>
     <properties>
       <property name="hibernate.hbm2ddl.auto" value="update"/>

--- a/model/src/main/java/com/infoloxa/catequesis/model/Usuarios.java
+++ b/model/src/main/java/com/infoloxa/catequesis/model/Usuarios.java
@@ -1,0 +1,61 @@
+package com.infoloxa.catequesis.model;
+
+import java.io.Serializable;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+@Entity
+@Table(name = "usuarios", schema = "catequesis")
+public class Usuarios implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    @Column(name = "nombre")
+    private String nombre;
+
+    @Column(name = "usuario", length = 50)
+    private String usuario;
+
+    @Column(name = "clave", length = 100)
+    private String clave;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getNombre() {
+        return nombre;
+    }
+
+    public void setNombre(String nombre) {
+        this.nombre = nombre;
+    }
+
+    public String getUsuario() {
+        return usuario;
+    }
+
+    public void setUsuario(String usuario) {
+        this.usuario = usuario;
+    }
+
+    public String getClave() {
+        return clave;
+    }
+
+    public void setClave(String clave) {
+        this.clave = clave;
+    }
+}

--- a/vistas/src/main/java/com/infoloxa/catequesis/vistas/EstudianteController.java
+++ b/vistas/src/main/java/com/infoloxa/catequesis/vistas/EstudianteController.java
@@ -9,7 +9,6 @@ package com.infoloxa.catequesis.vistas;
 
 import com.infoloxa.catequesis.excepciones.EntidadNoGrabadaException;
 import com.infoloxa.catequesis.logica.servicios.CatequesisService;
-import com.infoloxa.catequesis.logica.servicios.Imp.CatequesisServiceImpl;
 import com.infoloxa.catequesis.model.Estudiantes;
 import java.io.Serializable;
 import java.util.List;
@@ -40,8 +39,8 @@ public class EstudianteController implements Serializable {
     CatequesisService catequesisServicio;
     
     public void inform(){
-        List<Estudiantes> ontenerEstudiantes = catequesisServicio.ontenerEstudiantes();
-        estudianteDM.setListaEstudiantes(ontenerEstudiantes);
+        List<Estudiantes> listaEstudiantes = catequesisServicio.obtenerEstudiantes();
+        estudianteDM.setListaEstudiantes(listaEstudiantes);
     }
 
     public void nuevo(){

--- a/vistas/src/main/java/com/infoloxa/catequesis/vistas/EstudianteDM.java
+++ b/vistas/src/main/java/com/infoloxa/catequesis/vistas/EstudianteDM.java
@@ -7,6 +7,7 @@ package com.infoloxa.catequesis.vistas;
 
 
 import com.infoloxa.catequesis.model.Estudiantes;
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 import javax.faces.bean.ManagedBean;
@@ -18,7 +19,9 @@ import javax.faces.bean.ViewScoped;
  */
 @ManagedBean(name = "estudianteDM")
 @ViewScoped
-public class EstudianteDM {
+public class EstudianteDM implements Serializable {
+
+    private static final long serialVersionUID = 1L;
 
     private List<Estudiantes> listaEstudiantes= new ArrayList<>();
     private Estudiantes estudiantes= new Estudiantes();

--- a/vistas/src/main/java/com/infoloxa/catequesis/vistas/LoginController.java
+++ b/vistas/src/main/java/com/infoloxa/catequesis/vistas/LoginController.java
@@ -2,11 +2,15 @@ package com.infoloxa.catequesis.vistas;
 
 import java.io.IOException;
 import java.io.Serializable;
+import java.util.List;
 import java.util.ResourceBundle;
 import javax.faces.application.FacesMessage;
 import javax.faces.bean.ManagedBean;
 import javax.faces.bean.SessionScoped;
 import javax.faces.context.FacesContext;
+import javax.ejb.EJB;
+import com.infoloxa.catequesis.logica.dao.UsuarioDao;
+import com.infoloxa.catequesis.model.Usuarios;
 
 @ManagedBean(name = "loginController")
 @SessionScoped
@@ -14,20 +18,23 @@ public class LoginController implements Serializable {
 
     private static final long serialVersionUID = 1L;
 
+    @EJB(lookup = "java:global/logica-1.0/UsuarioDaoImpl!com.infoloxa.catequesis.logica.dao.UsuarioDao")
+    private UsuarioDao usuarioDao;
+
     private String usuario;
     private String clave;
     private boolean autenticado;
 
     public String ingresar() {
-        if ("admin".equals(usuario) && "admin".equals(clave)) {
+        List<Usuarios> usuarios = usuarioDao.buscarUsuario(usuario, clave);
+        if (!usuarios.isEmpty()) {
             autenticado = true;
             return "/pages/catequesis/index.xhtml?faces-redirect=true";
-        } else {
-            String msg = ResourceBundle.getBundle("MessageResources").getString("login_incorrecto");
-            FacesContext.getCurrentInstance().addMessage(null,
-                    new FacesMessage(FacesMessage.SEVERITY_ERROR, msg, null));
-            return null;
         }
+        String msg = ResourceBundle.getBundle("MessageResources").getString("login_incorrecto");
+        FacesContext.getCurrentInstance().addMessage(null,
+                new FacesMessage(FacesMessage.SEVERITY_ERROR, msg, null));
+        return null;
     }
 
     public void cerrarSesion() throws IOException {

--- a/vistas/src/main/java/com/infoloxa/catequesis/vistas/LoginController.java
+++ b/vistas/src/main/java/com/infoloxa/catequesis/vistas/LoginController.java
@@ -1,0 +1,58 @@
+package com.infoloxa.catequesis.vistas;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.ResourceBundle;
+import javax.faces.application.FacesMessage;
+import javax.faces.bean.ManagedBean;
+import javax.faces.bean.SessionScoped;
+import javax.faces.context.FacesContext;
+
+@ManagedBean(name = "loginController")
+@SessionScoped
+public class LoginController implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private String usuario;
+    private String clave;
+    private boolean autenticado;
+
+    public String ingresar() {
+        if ("admin".equals(usuario) && "admin".equals(clave)) {
+            autenticado = true;
+            return "/pages/catequesis/index.xhtml?faces-redirect=true";
+        } else {
+            String msg = ResourceBundle.getBundle("MessageResources").getString("login_incorrecto");
+            FacesContext.getCurrentInstance().addMessage(null,
+                    new FacesMessage(FacesMessage.SEVERITY_ERROR, msg, null));
+            return null;
+        }
+    }
+
+    public void cerrarSesion() throws IOException {
+        autenticado = false;
+        FacesContext.getCurrentInstance().getExternalContext().invalidateSession();
+        FacesContext.getCurrentInstance().getExternalContext().redirect("faces/pages/login.xhtml");
+    }
+
+    public boolean isAutenticado() {
+        return autenticado;
+    }
+
+    public String getUsuario() {
+        return usuario;
+    }
+
+    public void setUsuario(String usuario) {
+        this.usuario = usuario;
+    }
+
+    public String getClave() {
+        return clave;
+    }
+
+    public void setClave(String clave) {
+        this.clave = clave;
+    }
+}

--- a/vistas/src/main/java/com/infoloxa/catequesis/vistas/LoginController.java
+++ b/vistas/src/main/java/com/infoloxa/catequesis/vistas/LoginController.java
@@ -32,8 +32,11 @@ public class LoginController implements Serializable {
 
     public void cerrarSesion() throws IOException {
         autenticado = false;
-        FacesContext.getCurrentInstance().getExternalContext().invalidateSession();
-        FacesContext.getCurrentInstance().getExternalContext().redirect("faces/pages/login.xhtml");
+        FacesContext faces = FacesContext.getCurrentInstance();
+        faces.getExternalContext().invalidateSession();
+        String loginPage = faces.getExternalContext().getRequestContextPath()
+                + "/faces/pages/login.xhtml";
+        faces.getExternalContext().redirect(loginPage);
     }
 
     public boolean isAutenticado() {

--- a/vistas/src/main/java/com/infoloxa/catequesis/vistas/LoginFilter.java
+++ b/vistas/src/main/java/com/infoloxa/catequesis/vistas/LoginFilter.java
@@ -1,0 +1,41 @@
+package com.infoloxa.catequesis.vistas;
+
+import java.io.IOException;
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
+
+public class LoginFilter implements Filter {
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+            throws IOException, ServletException {
+        HttpServletRequest req = (HttpServletRequest) request;
+        HttpServletResponse res = (HttpServletResponse) response;
+        HttpSession session = req.getSession(false);
+        LoginController login = (session != null) ? (LoginController) session.getAttribute("loginController") : null;
+        boolean loggedIn = login != null && login.isAutenticado();
+        String loginURI = req.getContextPath() + "/faces/pages/login.xhtml";
+        boolean loginRequest = req.getRequestURI().equals(loginURI)
+                || req.getRequestURI().startsWith(req.getContextPath() + "/javax.faces.resource");
+        if (loggedIn || loginRequest) {
+            chain.doFilter(request, response);
+        } else {
+            res.sendRedirect(loginURI);
+        }
+    }
+
+    @Override
+    public void init(FilterConfig filterConfig) throws ServletException {
+    }
+
+    @Override
+    public void destroy() {
+    }
+}

--- a/vistas/src/main/webapp/WEB-INF/web.xml
+++ b/vistas/src/main/webapp/WEB-INF/web.xml
@@ -23,16 +23,24 @@
             <param-value>512000</param-value>
         </init-param>
     </filter>
+    <filter>
+        <filter-name>LoginFilter</filter-name>
+        <filter-class>com.infoloxa.catequesis.vistas.LoginFilter</filter-class>
+    </filter>
     <filter-mapping>
         <filter-name>PrimeFaces FileUpload Filter</filter-name>
         <servlet-name>Faces Servlet</servlet-name>
+    </filter-mapping>
+    <filter-mapping>
+        <filter-name>LoginFilter</filter-name>
+        <url-pattern>/faces/pages/*</url-pattern>
     </filter-mapping>
     <servlet-mapping>
         <servlet-name>Faces Servlet</servlet-name>
         <url-pattern>*.jsf</url-pattern>
     </servlet-mapping>
     <welcome-file-list>
-        <welcome-file>faces/index.html</welcome-file>
+        <welcome-file>faces/pages/login.xhtml</welcome-file>
     </welcome-file-list>
     
 </web-app>

--- a/vistas/src/main/webapp/pages/catequesis/index.xhtml
+++ b/vistas/src/main/webapp/pages/catequesis/index.xhtml
@@ -6,6 +6,7 @@
     <ui:composition template="/WEB-INF/templates/newTemplate.xhtml"> 
         <!-- ADMINISTRACION DE ACTIVOS FIJOS  -->
         <ui:define name="content">
+            <h:commandButton value="Cerrar Sesión" actionListener="#{loginController.cerrarSesion}" ajax="false" />
             <h:form id="form">
                 <p:growl id="mensaje" />
                 <ui:include src="tabla.xhtml"  />

--- a/vistas/src/main/webapp/pages/login.xhtml
+++ b/vistas/src/main/webapp/pages/login.xhtml
@@ -1,0 +1,20 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:h="http://java.sun.com/jsf/html"
+      xmlns:ui="http://java.sun.com/jsf/facelets"
+      xmlns:p="http://primefaces.org/ui">
+    <ui:composition template="/WEB-INF/templates/newTemplate.xhtml">
+        <ui:define name="content">
+            <h:form>
+                <p:messages />
+                <h:panelGrid columns="2">
+                    <h:outputLabel for="usuario" value="Usuario" />
+                    <p:inputText id="usuario" value="#{loginController.usuario}" required="true" />
+                    <h:outputLabel for="clave" value="Clave" />
+                    <p:password id="clave" value="#{loginController.clave}" required="true" />
+                </h:panelGrid>
+                <p:commandButton value="Ingresar" action="#{loginController.ingresar()}" update="@form" />
+            </h:form>
+        </ui:define>
+    </ui:composition>
+</html>


### PR DESCRIPTION
## Summary
- implement `LoginController` bean for handling credentials
- add `LoginFilter` to restrict access to pages
- create `login.xhtml` page
- wire filter and login page in `web.xml`
- include logout control on student list page

## Testing
- `mvn -q -DskipTests package` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844cf12e920832aaa3f06aa124f546d